### PR TITLE
Align with EFI_DT_FIXUP_PROTOCOL

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -212,7 +212,7 @@ EFI_STATUS efi_dt_fixup(EFI_DT_FIXUP_PROTOCOL *this, void *dtb, UINTN *size, UIN
 	ret = fdt_open_into(dtb, dtb, *size);
 	if (ret) {
 		Print(L"(dtbloader) fdt open failed: %d\n", ret);
-		return EFI_LOAD_ERROR;
+		return EFI_INVALID_PARAMETER;
 	}
 
 	if (flags & EFI_DT_APPLY_FIXUPS) {

--- a/src/main.c
+++ b/src/main.c
@@ -201,6 +201,9 @@ EFI_STATUS efi_dt_fixup(EFI_DT_FIXUP_PROTOCOL *this, void *dtb, UINTN *size, UIN
 	if (!dev)
 		return EFI_UNSUPPORTED;
 
+	if (!flags || flags & ~(EFI_DT_APPLY_FIXUPS | EFI_DT_RESERVE_MEMORY))
+		return EFI_INVALID_PARAMETER;
+
 	if (fdt_check_header(dtb))
 		return EFI_INVALID_PARAMETER;
 


### PR DESCRIPTION
* Check flags parameter in efi_dt_fixup(). EFI_INVALID_PARAMETER if flags is zero or contains unexpected bit.
* Return EFI_INVALID_PARAMETER if device-tree is invalid. EFI_LOAD_ERROR is not foreseen in the specification.