### PR TITLE
devices: surface11: Use DPP for mac provisioning

### DIFF
--- a/src/devices/microsoft_surface11.c
+++ b/src/devices/microsoft_surface11.c
@@ -29,5 +29,7 @@ static struct device microsoft_corporation_microsoft_surface_pro__11th_edition_d
 	.name  = L"Microsoft Corporation Microsoft Surface Pro, 11th Edition",
 	.dtb   = L"qcom\\x1e80100-microsoft-denali.dtb", /* Tentative. */
 	.hwids = microsoft_corporation_microsoft_surface_pro__11th_edition_hwids,
+
+	.dt_fixup = qcom_dt_set_dpp_mac,
 };
 DEVICE_DESC(microsoft_corporation_microsoft_surface_pro__11th_edition_dev);

--- a/src/qcom.c
+++ b/src/qcom.c
@@ -271,11 +271,13 @@ EFI_STATUS qcom_dt_set_dpp_mac(struct device *dev, void *dtb)
 		"qcom,wcnss-wlan",
 		"qcom,wcn3990-wifi",
 		"pci17cb,1103",
+		"pci17cb,1107",
 	};
 	const char * const bd_compatibles[] = {
 		"qcom,wcnss-bt",
 		"qcom,wcn3991-bt",
 		"qcom,wcn6855-bt",
+		"qcom,wcn7850-bt",
 	};
 
 	status = locate_dpp(&dpp_partition);

--- a/src/qcom.c
+++ b/src/qcom.c
@@ -198,7 +198,7 @@ static EFI_STATUS qcom_dpp_read_file(EFI_HANDLE dpp_partition, CHAR16 *file_name
 		if (!blob.present)
 			break;
 
-		if (!StrCmp(file_name, blob.name)) {
+		if (!StriCmp(file_name, blob.name)) {
 			len = blob.data_len;
 			buf = AllocatePool(len);
 


### PR DESCRIPTION
The Surface Pro 11 uses mixed-case file names for the provisioning data in the DPP; `Wlan.Provision` and `BT.Provision`. This was verified by using a UEFI shell to run `dblk BLK8 -b` and examine the RWFS partition.

Using `StriCmp()` allows these files to be picked up and the correct MAC/BD addresses are extracted from the DPP.

The relevant hardware IDs for WLAN/BT were added.

With these changes, Bluetooth MAC provisioning now 'just works' on the Surface Pro 11, but it looks like ath12k currently lacks any functionality to make use of a `local-mac-address` device tree property for WLAN.