### PR TITLE
devices: Remove tentative notes from X1E Dells

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ attemtps to simplify running Linux-based or other OS that use DT by providing:
 - <!-- x1e80100 --> ASUS Vivobook S 15
 - <!-- x1p42100 --> ASUS Zenbook A14 UX3407QA
 - <!-- x1e80100 --> ASUS Zenbook A14 UX3407RA
-- *<!-- x1e80100 --> Dell Inspiron 14 Plus 7441*
+- <!-- x1e80100 --> Dell Inspiron 14 Plus 7441
 - *<!-- x1p64100 --> Dell Latitude 5455*
-- *<!-- x1e80100 --> Dell Latitude 7455*
+- <!-- x1e80100 --> Dell Latitude 7455
 - <!-- x1e80100 --> Dell XPS 13 9345
 - <!-- x1e80100 --> HP EliteBook Ultra G1q 14
 - <!-- x1e80100 --> HP Omnibook X 14

--- a/src/devices/dell_inspiron-14-plus-7441.c
+++ b/src/devices/dell_inspiron-14-plus-7441.c
@@ -27,7 +27,7 @@ static EFI_GUID dell_inc__inspiron_14_plus_7441_hwids[] = {
 
 static struct device dell_inc__inspiron_14_plus_7441_dev = {
 	.name  = L"Dell Inc. Inspiron 14 Plus 7441",
-	.dtb   = L"qcom\\x1e80100-dell-inspiron-14-plus-7441.dtb", /* Tentative */
+	.dtb   = L"qcom\\x1e80100-dell-inspiron-14-plus-7441.dtb",
 	.hwids = dell_inc__inspiron_14_plus_7441_hwids,
 };
 DEVICE_DESC(dell_inc__inspiron_14_plus_7441_dev);

--- a/src/devices/dell_latitude_7455.c
+++ b/src/devices/dell_latitude_7455.c
@@ -27,7 +27,7 @@ static EFI_GUID dell_latitude_7455_hwids[] = {
 
 static struct device dell_latitude_7455_dev = {
 	.name  = L"Dell Inc. Latitude 7455",
-	.dtb   = L"qcom\\x1e80100-dell-latitude-7455.dtb", /* Tentative */
+	.dtb   = L"qcom\\x1e80100-dell-latitude-7455.dtb",
 	.hwids = dell_latitude_7455_hwids,
 };
 DEVICE_DESC(dell_latitude_7455_dev);


### PR DESCRIPTION
These have been upstreamed and are part of `linux-next` currently:
- https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/arch/arm64/boot/dts/qcom/x1e80100-dell-inspiron-14-plus-7441.dts?h=next-20250905
- https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/tree/arch/arm64/boot/dts/qcom/x1e80100-dell-latitude-7455.dts?h=next-20250905