### PR TITLE
chid: Zero-initialize SMBIOS info properly

### DIFF
--- a/src/chid.c
+++ b/src/chid.c
@@ -109,6 +109,13 @@ static EFI_STATUS populate_raw_smbios_info(struct raw_smbios_info *info)
 	else
 		return EFI_NOT_FOUND;
 
+	info->Manufacturer = NULL;
+	info->ProductName = NULL;
+	info->ProductSku = NULL;
+	info->Family = NULL;
+	info->BaseboardManufacturer = NULL;
+	info->BaseboardProduct = NULL;
+
 	while (Smbios.Hdr->Type != 127) {
 
 		switch (Smbios.Hdr->Type) {


### PR DESCRIPTION
Some firmwares do not provide baseboard information, which results in uninitialized struct fields, which are then dereferenced later, resulting in crashes. Fix this by always zeroing the struct fields.